### PR TITLE
Update API to track bases/players of Plateappearance

### DIFF
--- a/app/controllers/plateappearances_controller.rb
+++ b/app/controllers/plateappearances_controller.rb
@@ -46,6 +46,6 @@ class PlateappearancesController < ProtectedController
 
     # Only allow a trusted parameter "white list" through.
     def plateappearance_params
-      params.require(:plateappearance).permit(:inning, :inninghalf, :batter, :pitcher, :runs, :outs, :def_error, :outcome, :game_id)
+      params.require(:plateappearance).permit(:firstbase, :secondbase, :thirdbase, :homebase, :firstbasemandefense, :secondbasemandefense, :thirdbasemandefense, :shortstopdefense, :leftfielddefense, :centerfielddefense, :rightfielddefense, :catcherdefense, :pitcherdefense, :homer, :inning, :inninghalf, :batter, :pitcher, :runs, :outs, :def_error, :outcome, :game_id)
     end
 end

--- a/app/serializers/plateappearance_serializer.rb
+++ b/app/serializers/plateappearance_serializer.rb
@@ -1,5 +1,5 @@
 class PlateappearanceSerializer < ActiveModel::Serializer
-  attributes :id, :inninghalf, :inning, :batter, :pitcher, :runs, :outs, :def_error, :outcome, :game
+  attributes :id, :inninghalf, :inning, :batter, :pitcher, :runs, :outs, :def_error, :outcome, :firstbase, :secondbase, :thirdbase, :homebase, :firstbasemandefense, :secondbasemandefense, :thirdbasemandefense, :shortstopdefense, :leftfielddefense, :centerfielddefense, :rightfielddefense, :catcherdefense, :pitcherdefense, :homer, :game
 
   def game
     object.game.id

--- a/db/migrate/20170831143202_add_base_player_arrays_to_plateappearances.rb
+++ b/db/migrate/20170831143202_add_base_player_arrays_to_plateappearances.rb
@@ -1,0 +1,18 @@
+class AddBasePlayerArraysToPlateappearances < ActiveRecord::Migration[5.0]
+  def change
+    add_column :plateappearances, :firstbase, :boolean
+    add_column :plateappearances, :secondbase, :boolean
+    add_column :plateappearances, :thirdbase, :boolean
+    add_column :plateappearances, :homebase, :boolean
+    add_column :plateappearances, :firstbasemandefense, :boolean
+    add_column :plateappearances, :secondbasemandefense, :boolean
+    add_column :plateappearances, :thirdbasemandefense, :boolean
+    add_column :plateappearances, :shortstopdefense, :boolean
+    add_column :plateappearances, :leftfielddefense, :boolean
+    add_column :plateappearances, :centerfielddefense, :boolean
+    add_column :plateappearances, :rightfielddefense, :boolean
+    add_column :plateappearances, :catcherdefense, :boolean
+    add_column :plateappearances, :pitcherdefense, :boolean
+    add_column :plateappearances, :homer, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170829185538) do
+ActiveRecord::Schema.define(version: 20170831143202) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,12 +25,14 @@ ActiveRecord::Schema.define(version: 20170829185538) do
   end
 
   create_table "games", force: :cascade do |t|
-    t.string   "date",       null: false
-    t.string   "home",       null: false
-    t.string   "away",       null: false
-    t.integer  "user_id",    null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "date",                    null: false
+    t.string   "home",                    null: false
+    t.string   "away",                    null: false
+    t.integer  "user_id",                 null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.text     "hroster",    default: [],              array: true
+    t.text     "aroster",    default: [],              array: true
     t.index ["user_id"], name: "index_games_on_user_id", using: :btree
   end
 
@@ -43,9 +45,23 @@ ActiveRecord::Schema.define(version: 20170829185538) do
     t.integer  "def_error"
     t.string   "outcome"
     t.integer  "game_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
     t.string   "inninghalf"
+    t.boolean  "firstbase"
+    t.boolean  "secondbase"
+    t.boolean  "thirdbase"
+    t.boolean  "homebase"
+    t.boolean  "firstbasemandefense"
+    t.boolean  "secondbasemandefense"
+    t.boolean  "thirdbasemandefense"
+    t.boolean  "shortstopdefense"
+    t.boolean  "leftfielddefense"
+    t.boolean  "centerfielddefense"
+    t.boolean  "rightfielddefense"
+    t.boolean  "catcherdefense"
+    t.boolean  "pitcherdefense"
+    t.boolean  "homer"
     t.index ["game_id"], name: "index_plateappearances_on_game_id", using: :btree
   end
 

--- a/tests/unit/transforms/array-test.js
+++ b/tests/unit/transforms/array-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('transform:array', 'Unit | Transform | array', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let transform = this.subject();
+  assert.ok(transform);
+});


### PR DESCRIPTION
Add columns to the plateappearance table to track the state of bases
and defensive players on the field with boolean values, which allows
users to store that data and access it again when they view each
PA.