### PR TITLE
Add data columns to games resource

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -46,7 +46,14 @@ class GamesController < ProtectedController
 
     # Only allow a trusted parameter "white list" through.
     def game_params
-      params.require(:game).permit(:date, :home, :away)
+      params.require(:game).permit(:date, :home, :away, :away_runs, :home_runs,
+      :away_hits, :home_hits, :away_errors, :home_errors, :total_innings, :top_one,
+      :bot_one, :top_two, :bot_two, :top_three, :bot_three, :top_four, :bot_four,
+      :top_five, :bot_five, :top_six, :bot_six, :top_seven, :bot_seven, :top_eight,
+      :bot_eight, :top_nine, :bot_nine, :top_ten, :bot_ten, :top_eleven, :bot_eleven,
+      :top_twelve, :bot_twelve, :top_thirteen, :bot_thirteen, :top_fourteen, :bot_fourteen,
+      :top_fifteen, :bot_fifteen, :top_sixteen, :bot_sixteen, :top_seventeen, :bot_seventeen,
+      :top_eighteen, :bot_eighteen)
     end
 
 end

--- a/app/serializers/game_serializer.rb
+++ b/app/serializers/game_serializer.rb
@@ -1,5 +1,12 @@
 class GameSerializer < ActiveModel::Serializer
-  attributes :id, :date, :home, :away, :user, :plateappearances
+  attributes :id, :date, :home, :away, :away_runs, :home_runs,
+  :away_hits, :home_hits, :away_errors, :home_errors, :total_innings, :top_one,
+  :bot_one, :top_two, :bot_two, :top_three, :bot_three, :top_four, :bot_four,
+  :top_five, :bot_five, :top_six, :bot_six, :top_seven, :bot_seven, :top_eight,
+  :bot_eight, :top_nine, :bot_nine, :top_ten, :bot_ten, :top_eleven, :bot_eleven,
+  :top_twelve, :bot_twelve, :top_thirteen, :bot_thirteen, :top_fourteen, :bot_fourteen,
+  :top_fifteen, :bot_fifteen, :top_sixteen, :bot_sixteen, :top_seventeen, :bot_seventeen,
+  :top_eighteen, :bot_eighteen, :plateappearances
 
   def plateappearances
     object.plateappearances.pluck(:id)

--- a/db/migrate/20170909232643_add_game_data_columns.rb
+++ b/db/migrate/20170909232643_add_game_data_columns.rb
@@ -1,0 +1,47 @@
+class AddGameDataColumns < ActiveRecord::Migration[5.0]
+  def change
+    add_column :games, :away_runs, :integer
+    add_column :games, :away_hits, :integer
+    add_column :games, :away_errors, :integer
+    add_column :games, :home_runs, :integer
+    add_column :games, :home_hits, :integer
+    add_column :games, :home_errors, :integer
+    add_column :games, :total_innings, :integer
+    add_column :games, :top_one, :integer
+    add_column :games, :top_two, :integer
+    add_column :games, :top_three, :integer
+    add_column :games, :top_four, :integer
+    add_column :games, :top_five, :integer
+    add_column :games, :top_six, :integer
+    add_column :games, :top_seven, :integer
+    add_column :games, :top_eight, :integer
+    add_column :games, :top_nine, :integer
+    add_column :games, :top_ten, :integer
+    add_column :games, :top_eleven, :integer
+    add_column :games, :top_twelve, :integer
+    add_column :games, :top_thirteen, :integer
+    add_column :games, :top_fourteen, :integer
+    add_column :games, :top_fifteen, :integer
+    add_column :games, :top_sixteen, :integer
+    add_column :games, :top_seventeen, :integer
+    add_column :games, :top_eighteen, :integer
+    add_column :games, :bot_one, :integer
+    add_column :games, :bot_two, :integer
+    add_column :games, :bot_three, :integer
+    add_column :games, :bot_four, :integer
+    add_column :games, :bot_five, :integer
+    add_column :games, :bot_six, :integer
+    add_column :games, :bot_seven, :integer
+    add_column :games, :bot_eight, :integer
+    add_column :games, :bot_nine, :integer
+    add_column :games, :bot_ten, :integer
+    add_column :games, :bot_eleven, :integer
+    add_column :games, :bot_twelve, :integer
+    add_column :games, :bot_thirteen, :integer
+    add_column :games, :bot_fourteen, :integer
+    add_column :games, :bot_fifteen, :integer
+    add_column :games, :bot_sixteen, :integer
+    add_column :games, :bot_seventeen, :integer
+    add_column :games, :bot_eighteen, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170831143202) do
+ActiveRecord::Schema.define(version: 20170909232643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,14 +25,57 @@ ActiveRecord::Schema.define(version: 20170831143202) do
   end
 
   create_table "games", force: :cascade do |t|
-    t.string   "date",                    null: false
-    t.string   "home",                    null: false
-    t.string   "away",                    null: false
-    t.integer  "user_id",                 null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.text     "hroster",    default: [],              array: true
-    t.text     "aroster",    default: [],              array: true
+    t.string   "date",                       null: false
+    t.string   "home",                       null: false
+    t.string   "away",                       null: false
+    t.integer  "user_id",                    null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.text     "hroster",       default: [],              array: true
+    t.text     "aroster",       default: [],              array: true
+    t.integer  "away_runs"
+    t.integer  "away_hits"
+    t.integer  "away_errors"
+    t.integer  "home_runs"
+    t.integer  "home_hits"
+    t.integer  "home_errors"
+    t.integer  "total_innings"
+    t.integer  "top_one"
+    t.integer  "top_two"
+    t.integer  "top_three"
+    t.integer  "top_four"
+    t.integer  "top_five"
+    t.integer  "top_six"
+    t.integer  "top_seven"
+    t.integer  "top_eight"
+    t.integer  "top_nine"
+    t.integer  "top_ten"
+    t.integer  "top_eleven"
+    t.integer  "top_twelve"
+    t.integer  "top_thirteen"
+    t.integer  "top_fourteen"
+    t.integer  "top_fifteen"
+    t.integer  "top_sixteen"
+    t.integer  "top_seventeen"
+    t.integer  "top_eighteen"
+    t.integer  "bot_one"
+    t.integer  "bot_two"
+    t.integer  "bot_three"
+    t.integer  "bot_four"
+    t.integer  "bot_five"
+    t.integer  "bot_six"
+    t.integer  "bot_seven"
+    t.integer  "bot_eight"
+    t.integer  "bot_nine"
+    t.integer  "bot_ten"
+    t.integer  "bot_eleven"
+    t.integer  "bot_twelve"
+    t.integer  "bot_thirteen"
+    t.integer  "bot_fourteen"
+    t.integer  "bot_fifteen"
+    t.integer  "bot_sixteen"
+    t.integer  "bot_seventeen"
+    t.integer  "bot_eighteen"
     t.index ["user_id"], name: "index_games_on_user_id", using: :btree
   end
 


### PR DESCRIPTION
adds columns to store runs per inning and other data to the games
resource, previously only calculated on the front end. Storing
this data in the API allows for access to the data when building
ember charts.